### PR TITLE
Fix authorization status button refresh after camera permission activ…

### DIFF
--- a/PAPermissions/Classes/Checks/PACameraPermissionsCheck.swift
+++ b/PAPermissions/Classes/Checks/PACameraPermissionsCheck.swift
@@ -51,9 +51,9 @@ public class PACameraPermissionsCheck: PAPermissionsCheck {
 							self.status = .enabled
 						}else{
 							self.status = .disabled
-						}
+                        }
+                        self.updateStatus();
 					})
-					self.updateStatus();
 				}
 			}else{
 				//Camera access should be always active on iOS 7


### PR DESCRIPTION
Hi,

I've found a little bug when user accept camera permission, the status button was not refreshing because the _updateStatus_ method isn't called in authorization block. Do you agree ?