### PR TITLE
Removed implicit and forced unwrapping

### DIFF
--- a/Example/PAPermissionsApp/ViewController.swift
+++ b/Example/PAPermissionsApp/ViewController.swift
@@ -13,8 +13,9 @@ class ViewController: UIViewController {
 	
 	@IBAction func didShowPermissions(_ sender: AnyObject) {
 		
-		let controller = self.storyboard?.instantiateViewController(withIdentifier: "CustomPermissionsViewController")
-		self.present(controller!, animated: true, completion: nil)
+		if let controller = self.storyboard?.instantiateViewController(withIdentifier: "CustomPermissionsViewController") {
+			self.present(controller, animated: true, completion: nil)
+		}
 	}
 	override func viewDidLoad() {
 		super.viewDidLoad()

--- a/PAPermissions/Classes/Checks/PABluetoothPermissionsCheck.swift
+++ b/PAPermissions/Classes/Checks/PABluetoothPermissionsCheck.swift
@@ -20,9 +20,13 @@ public class PABluetoothPermissionsCheck: PAPermissionsCheck, CBCentralManagerDe
 	}
 	
 	public func centralManagerDidUpdateState(_ central: CBCentralManager) {
+		guard let managerBLE = managerBLE else {
+			return
+		}
+		
 		let currentStatus = self.status
 
-		switch managerBLE!.state
+		switch managerBLE.state
 		{
 		case .poweredOff:
 			self.status = .disabled

--- a/PAPermissions/Classes/Checks/PAEventKitPermissionsCheck.swift
+++ b/PAPermissions/Classes/Checks/PAEventKitPermissionsCheck.swift
@@ -28,9 +28,13 @@ public class PAEKPermissionsCheck: PAPermissionsCheck {
 	var entityType : EKEntityType?
 
 	public override func checkStatus() {
+		guard let entityType = entityType else {
+			return
+		}
+		
 		let currentStatus = status
 
-		switch EKEventStore.authorizationStatus(for: entityType!) {
+		switch EKEventStore.authorizationStatus(for: entityType) {
 		case .authorized:
 			status = .enabled
 		case .denied:
@@ -47,11 +51,15 @@ public class PAEKPermissionsCheck: PAPermissionsCheck {
 	}
 
 	public override func defaultAction() {
-		let status = EKEventStore.authorizationStatus(for: entityType!)
+		guard let entityType = entityType else {
+			return
+		}
+		
+		let status = EKEventStore.authorizationStatus(for: entityType)
 		if status == .denied {
 			self.openSettings()
 		} else {
-			EKEventStore().requestAccess(to: entityType!, completion: { (success, error) in
+			EKEventStore().requestAccess(to: entityType, completion: { (success, error) in
 				if success && error == nil {
 					self.status = .enabled
 				} else {

--- a/PAPermissions/Classes/Checks/PAPermissionsCheck.swift
+++ b/PAPermissions/Classes/Checks/PAPermissionsCheck.swift
@@ -34,7 +34,8 @@ open class PAPermissionsCheck: NSObject {
 	}
 	
 	public func openSettings() {
-		let settingsURL = URL(string: UIApplication.openSettingsURLString)
-		UIApplication.shared.open(settingsURL!, options: [:], completionHandler: nil)
+		if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+			UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
+		}
 	}
 }

--- a/PAPermissions/Classes/PAPermissionsTableViewCell.swift
+++ b/PAPermissions/Classes/PAPermissionsTableViewCell.swift
@@ -12,15 +12,15 @@ class PAPermissionsTableViewCell: UITableViewCell {
 
 	var didSelectItem: ((PAPermissionsItem) -> ())?
 	
-	weak var iconImageView: UIImageView!
-	weak var titleLabel: UILabel!
-	weak var detailsLabel: UILabel!
+	let iconImageView: UIImageView = UIImageView()
+	let titleLabel: UILabel = UILabel()
+	let detailsLabel: UILabel = UILabel()
 	
-	weak var permission: PAPermissionsItem!
+	var permission: PAPermissionsItem?
 	
-	fileprivate weak var rightDetailsContainer: UIView!
-	fileprivate weak var enableButton: UIButton!
-	fileprivate weak var checkingIndicator: UIActivityIndicatorView!
+	fileprivate let rightDetailsContainer: UIView = UIView()
+	fileprivate let enableButton: UIButton = UIButton(type: .system)
+	fileprivate let checkingIndicator: UIActivityIndicatorView = UIActivityIndicatorView(style: .white)
 	
 	fileprivate var _permissionStatus = PAPermissionsStatus.disabled
 	var permissionStatus: PAPermissionsStatus {
@@ -88,26 +88,18 @@ class PAPermissionsTableViewCell: UITableViewCell {
 	}
 	
 	fileprivate func setupImageView() {
-		if self.iconImageView == nil {
-			let imageView = UIImageView()
-			imageView.contentMode = .scaleAspectFit
-			self.addSubview(imageView)
-			self.iconImageView = imageView
-			self.iconImageView.backgroundColor = UIColor.clear
-			self.iconImageView.translatesAutoresizingMaskIntoConstraints = false
-		}
+		iconImageView.contentMode = .scaleAspectFit
+		self.addSubview(iconImageView)
+		self.iconImageView.backgroundColor = UIColor.clear
+		self.iconImageView.translatesAutoresizingMaskIntoConstraints = false
 		self.iconImageView.tintColor = self.tintColor
 	}
 	
 	fileprivate func setupTitleLabel() {
-		if self.titleLabel == nil {
-			let titleLabel = UILabel()
-			titleLabel.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(titleLabel)
-			self.titleLabel = titleLabel
-			self.titleLabel.text = "Title"
-			self.titleLabel.adjustsFontSizeToFitWidth = true
-		}
+		titleLabel.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(titleLabel)
+		self.titleLabel.text = "Title"
+		self.titleLabel.adjustsFontSizeToFitWidth = true
 		
 		self.titleLabel.font = UIFont(name: "HelveticaNeue-Light", size: 15)
 		self.titleLabel.minimumScaleFactor = 0.1
@@ -115,14 +107,10 @@ class PAPermissionsTableViewCell: UITableViewCell {
 	}
 	
 	fileprivate func setupDetailsLabel() {
-		if self.detailsLabel == nil {
-			let detailsLabel = UILabel()
-			detailsLabel.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(detailsLabel)
-			self.detailsLabel = detailsLabel
-			self.detailsLabel.text = "details"
-			self.detailsLabel.adjustsFontSizeToFitWidth = true
-		}
+		detailsLabel.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(detailsLabel)
+		self.detailsLabel.text = "details"
+		self.detailsLabel.adjustsFontSizeToFitWidth = true
 		
 		self.detailsLabel.font = UIFont(name: "HelveticaNeue-Light", size: 11)
 		self.detailsLabel.minimumScaleFactor = 0.1
@@ -130,47 +118,37 @@ class PAPermissionsTableViewCell: UITableViewCell {
 	}
 	
 	fileprivate func setupRightDetailsContainer() {
-		if self.rightDetailsContainer == nil {
-			let rightDetailsContainer = UIView()
-			rightDetailsContainer.backgroundColor = UIColor.clear
-			rightDetailsContainer.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(rightDetailsContainer)
-			self.rightDetailsContainer = rightDetailsContainer
-			self.rightDetailsContainer.backgroundColor = UIColor.clear
-		}
+		rightDetailsContainer.backgroundColor = UIColor.clear
+		rightDetailsContainer.translatesAutoresizingMaskIntoConstraints = false
+		rightDetailsContainer.backgroundColor = UIColor.clear
+		self.addSubview(rightDetailsContainer)
 	}
 	
 	fileprivate func setupEnableButton(_ status: PAPermissionsStatus) {
-		if self.enableButton == nil {
-			let enableButton = UIButton(type: .system)
-			enableButton.translatesAutoresizingMaskIntoConstraints = false
-			self.rightDetailsContainer.addSubview(enableButton)
-			self.enableButton = enableButton
-			self.enableButton.backgroundColor = UIColor.red
-			self.enableButton.addTarget(self, action: #selector(PAPermissionsTableViewCell._didSelectItem), for: .touchUpInside)
-			
-			let checkingIndicator = UIActivityIndicatorView(style: .white)
-			checkingIndicator.translatesAutoresizingMaskIntoConstraints = false
-			self.rightDetailsContainer.addSubview(checkingIndicator)
-			self.checkingIndicator = checkingIndicator
+		enableButton.translatesAutoresizingMaskIntoConstraints = false
+		self.rightDetailsContainer.addSubview(enableButton)
+		self.enableButton.backgroundColor = UIColor.red
+		self.enableButton.addTarget(self, action: #selector(PAPermissionsTableViewCell._didSelectItem), for: .touchUpInside)
+		
+		checkingIndicator.translatesAutoresizingMaskIntoConstraints = false
+		self.rightDetailsContainer.addSubview(checkingIndicator)
 
-			let views = ["enableButton": self.enableButton,
-						 "checkingIndicator": self.checkingIndicator] as [String : UIView]
-			
-			var allConstraints = PAConstraintsUtils.concatenateConstraintsFromString([
-				"V:[enableButton(30)]",
-				"H:|-2-[enableButton]-2-|",
-				"V:|-0-[checkingIndicator]-0-|",
-				"H:|-0-[checkingIndicator]-0-|"
-				], views: views)
-			allConstraints.append(NSLayoutConstraint.init(item: self.enableButton, attribute: NSLayoutConstraint.Attribute.centerY, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self.enableButton.superview, attribute: NSLayoutConstraint.Attribute.centerY, multiplier: 1.0, constant: 0.0))
-			NSLayoutConstraint.activate(allConstraints)
-		}
+		let views = ["enableButton": self.enableButton,
+					 "checkingIndicator": self.checkingIndicator] as [String : UIView]
+		
+		var allConstraints = PAConstraintsUtils.concatenateConstraintsFromString([
+			"V:[enableButton(30)]",
+			"H:|-2-[enableButton]-2-|",
+			"V:|-0-[checkingIndicator]-0-|",
+			"H:|-0-[checkingIndicator]-0-|"
+			], views: views)
+		allConstraints.append(NSLayoutConstraint.init(item: self.enableButton, attribute: NSLayoutConstraint.Attribute.centerY, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self.enableButton.superview, attribute: NSLayoutConstraint.Attribute.centerY, multiplier: 1.0, constant: 0.0))
+		NSLayoutConstraint.activate(allConstraints)
 		
 		self.enableButton.tintColor = self.tintColor
 		
 		if status == .enabled {
-			if !self.permission.canBeDisabled {
+			if self.permission?.canBeDisabled == false {
 				self.enableButton.isHidden = false
 				self.checkingIndicator.isHidden = true
 				self.checkingIndicator.stopAnimating()
@@ -223,8 +201,8 @@ class PAPermissionsTableViewCell: UITableViewCell {
 	}
 	
 	@objc fileprivate func _didSelectItem() {
-		if self.didSelectItem != nil {
-			self.didSelectItem!(self.permission)
+		if let didSelectItem = didSelectItem, let permission = permission {
+			didSelectItem(permission)
 		}
 	}
 	

--- a/PAPermissions/Classes/PAPermissionsView.swift
+++ b/PAPermissions/Classes/PAPermissionsView.swift
@@ -130,28 +130,17 @@ public class PAPermissionsItem {
 
 class PAPermissionsView: UIView, UITableViewDataSource, UITableViewDelegate {
 
-	weak var titleLabel: UILabel!
-	weak var detailsLabel: UILabel!
-	weak var continueButton: UIButton!
+	let titleLabel: UILabel = UILabel()
+	let detailsLabel: UILabel = UILabel()
+	let continueButton: UIButton = UIButton(type: .system)
 	
 	var delegate: PAPermissionsViewDelegate?
 	var dataSource: PAPermissionsViewDataSource?
 	
-	fileprivate weak var tableView: UITableView!
-	fileprivate weak var refreshControl: UIRefreshControl!
-	fileprivate weak var imageView: UIImageView!
-	
-	fileprivate weak var _blurEffectView: AnyObject!
-	@available(iOS 8.0, *)
-	fileprivate weak var blurEffectView: UIVisualEffectView? {
-		get {
-			return self._blurEffectView as? UIVisualEffectView
-		}
-		
-		set(newView) {
-			self._blurEffectView = newView
-		}
-	}
+	fileprivate let tableView: UITableView = UITableView(frame: CGRect.zero, style: .plain)
+	fileprivate let imageView: UIImageView = UIImageView()
+
+	fileprivate var blurEffectView: UIVisualEffectView?
 	
 	var permissions: [PAPermissionsItem] = Array()
 	
@@ -165,7 +154,6 @@ class PAPermissionsView: UIView, UITableViewDataSource, UITableViewDelegate {
 		}
 	}
 	
-	@available (iOS 8, *)
 	var useBlurBackground: Bool {
 		get {
 			return self.blurEffectView != nil
@@ -265,55 +253,39 @@ class PAPermissionsView: UIView, UITableViewDataSource, UITableViewDelegate {
 	}
 	
 	fileprivate func setupTitleLabel() {
-		if self.titleLabel == nil {
-			let titleLabel = UILabel()
-			titleLabel.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(titleLabel)
-			self.titleLabel = titleLabel
-			self.titleLabel.text = "Title"
-		}
-		
+		titleLabel.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(titleLabel)
+		self.titleLabel.text = "Title"
 		self.titleLabel.font = UIFont(name: "HelveticaNeue-Light", size: 30)
 		self.titleLabel.minimumScaleFactor = 0.1
 		self.titleLabel.textColor = self.tintColor
 	}
 	
 	fileprivate func setupDetailsLabel() {
-		if self.detailsLabel == nil {
-			let detailsLabel = UILabel()
-			detailsLabel.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(detailsLabel)
-			self.detailsLabel = detailsLabel
-			self.detailsLabel.text = "Details"
-            // handle multi line details text
-            self.detailsLabel.numberOfLines = 0
-            self.detailsLabel.lineBreakMode = .byWordWrapping
-		}
-		
+		detailsLabel.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(detailsLabel)
+		self.detailsLabel.text = "Details"
+		// handle multi line details text
+		self.detailsLabel.numberOfLines = 0
+		self.detailsLabel.lineBreakMode = .byWordWrapping
 		self.detailsLabel.font = UIFont(name: "HelveticaNeue-Light", size: 15)
 		self.detailsLabel.minimumScaleFactor = 0.1
 		self.detailsLabel.textColor = self.tintColor
 	}
 	
 	fileprivate func setupTableView() {
-		if self.tableView == nil {
-			let tableView = UITableView(frame: CGRect.zero, style: .plain)
-			tableView.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(tableView)
-			self.tableView = tableView
-			self.tableView.backgroundColor = UIColor.clear
-			self.tableView.dataSource = self
-			self.tableView.delegate = self
-			self.tableView.register(PAPermissionsTableViewCell.self, forCellReuseIdentifier: "permission-item")
-			self.tableView.tableFooterView = UIView()
-			
-			let refreshControl = UIRefreshControl()
-			refreshControl.addTarget(self, action: #selector(PAPermissionsView.refresh(_:)), for: UIControl.Event.valueChanged)
-			tableView.addSubview(refreshControl)
-			self.refreshControl = refreshControl
-		}
+		tableView.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(tableView)
+		self.tableView.backgroundColor = UIColor.clear
+		self.tableView.dataSource = self
+		self.tableView.delegate = self
+		self.tableView.register(PAPermissionsTableViewCell.self, forCellReuseIdentifier: "permission-item")
+		self.tableView.tableFooterView = UIView()
+		
+		let refreshControl: UIRefreshControl = UIRefreshControl()
+		refreshControl.addTarget(self, action: #selector(PAPermissionsView.refresh(_:)), for: UIControl.Event.valueChanged)
+		tableView.addSubview(refreshControl)
 		refreshControl.tintColor = self.tintColor
-
 	}
 	
 	@objc fileprivate func refresh(_ sender:UIRefreshControl) {
@@ -324,13 +296,9 @@ class PAPermissionsView: UIView, UITableViewDataSource, UITableViewDelegate {
 	}
 	
 	fileprivate func setupContinueButton() {
-		if self.continueButton == nil {
-			let continueButton = UIButton(type: .system)
-			continueButton.translatesAutoresizingMaskIntoConstraints = false
-			self.addSubview(continueButton)
-			self.continueButton = continueButton
-			self.continueButton.backgroundColor = UIColor.red
-		}
+		continueButton.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(continueButton)
+		self.continueButton.backgroundColor = UIColor.red
 		self.continueButton.titleLabel?.font = UIFont(name: "HelveticaNeue-Regular", size: 14)
 		self.continueButton.titleLabel?.minimumScaleFactor = 0.1
 		self.continueButton.setTitle(NSLocalizedString("Continue", comment: ""), for: UIControl.State())
@@ -339,16 +307,12 @@ class PAPermissionsView: UIView, UITableViewDataSource, UITableViewDelegate {
 	}
 	
 	fileprivate func setupImageView() {
-		if self.imageView == nil {
-			let imageView = UIImageView()
-			imageView.contentMode = .scaleAspectFill
-			self.addSubview(imageView)
-			self.imageView = imageView
-			self.imageView.backgroundColor = UIColor.clear
-			imageView.translatesAutoresizingMaskIntoConstraints = false
-			imageView.superview!.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": imageView]))
-			imageView.superview!.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": imageView]))
-		}
+		imageView.contentMode = .scaleAspectFill
+		self.addSubview(imageView)
+		self.imageView.backgroundColor = UIColor.clear
+		imageView.translatesAutoresizingMaskIntoConstraints = false
+		imageView.superview?.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": imageView]))
+		imageView.superview?.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": imageView]))
 	}
 	
 	

--- a/PAPermissions/Classes/PAPermissionsView.swift
+++ b/PAPermissions/Classes/PAPermissionsView.swift
@@ -46,10 +46,10 @@ public class PAPermissionsItem {
 	var identifier: String
 	var title: String
 	var reason: String
-	var icon: UIImage
+	var icon: UIImage?
 	var canBeDisabled: Bool
 	
-	public init(type: PAPermissionsType, identifier: String, title: String, reason: String, icon: UIImage, canBeDisabled: Bool) {
+	public init(type: PAPermissionsType, identifier: String, title: String, reason: String, icon: UIImage?, canBeDisabled: Bool) {
 		self.type = type
 		self.identifier = identifier
 		self.title = title
@@ -101,27 +101,27 @@ public class PAPermissionsItem {
 
 		switch type {
 		case .bluetooth:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Bluetooth", comment: ""), reason: localReason, icon: UIImage(named: "pa_bluetooth_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Bluetooth", comment: ""), reason: localReason, icon: UIImage(named: "pa_bluetooth_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .location:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Location", comment: ""), reason: localReason, icon: UIImage(named: "pa_location_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Location", comment: ""), reason: localReason, icon: UIImage(named: "pa_location_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .notifications:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Notifications", comment: ""), reason: localReason, icon: UIImage(named: "pa_notification_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Notifications", comment: ""), reason: localReason, icon: UIImage(named: "pa_notification_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .microphone:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Microphone", comment: ""), reason: localReason, icon: UIImage(named: "pa_microphone_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Microphone", comment: ""), reason: localReason, icon: UIImage(named: "pa_microphone_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .motionFitness:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Motion Fitness", comment: ""), reason: localReason, icon: UIImage(named: "pa_motion_activity_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Motion Fitness", comment: ""), reason: localReason, icon: UIImage(named: "pa_motion_activity_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .camera:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Camera", comment: ""), reason: localReason, icon: UIImage(named: "pa_camera_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Camera", comment: ""), reason: localReason, icon: UIImage(named: "pa_camera_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .calendar:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Calendar", comment: ""), reason: localReason, icon: UIImage(named: "pa_calendar_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Calendar", comment: ""), reason: localReason, icon: UIImage(named: "pa_calendar_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .reminders:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Reminders", comment: ""), reason: localReason, icon: UIImage(named: "pa_reminders_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Reminders", comment: ""), reason: localReason, icon: UIImage(named: "pa_reminders_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .contacts:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Contacts", comment: ""), reason: localReason, icon: UIImage(named: "pa_contacts_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Contacts", comment: ""), reason: localReason, icon: UIImage(named: "pa_contacts_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .photoLibrary:
-			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Photo Library", comment: ""), reason: localReason, icon: UIImage(named: "pa_photo_library_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+			return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Photo Library", comment: ""), reason: localReason, icon: UIImage(named: "pa_photo_library_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		case .mediaLibrary:
-            return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Media Library", comment: ""), reason: localReason, icon: UIImage(named: "pa_media_library_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil)!, canBeDisabled: false)
+            return PAPermissionsItem(type: type, identifier: type.rawValue, title: NSLocalizedString("Media Library", comment: ""), reason: localReason, icon: UIImage(named: "pa_media_library_icon", in: Bundle(for: PAPermissionsViewController.self), compatibleWith: nil), canBeDisabled: false)
 		default:
 			return nil
 		}
@@ -339,7 +339,7 @@ class PAPermissionsView: UIView, UITableViewDataSource, UITableViewDelegate {
 		cell.selectionStyle = .none
 		cell.titleLabel.text = item.title
 		cell.detailsLabel.text = item.reason
-		cell.iconImageView.image = item.icon.withRenderingMode(.alwaysTemplate)
+		cell.iconImageView.image = item.icon?.withRenderingMode(.alwaysTemplate)
 		cell.permission = item
 		return cell
 	}

--- a/PAPermissions/Classes/PAPermissionsViewController.swift
+++ b/PAPermissions/Classes/PAPermissionsViewController.swift
@@ -33,7 +33,7 @@ open class PAPermissionsViewController: UIViewController, PAPermissionsViewDeleg
 	
 	public var delegate: PAPermissionsViewControllerDelegate?
 	fileprivate var permissionHandlers: [String: PAPermissionsCheck] = Dictionary()
-	fileprivate weak var permissionsView: PAPermissionsView!
+	fileprivate var permissionsView: PAPermissionsView = PAPermissionsView(frame: CGRect(origin: CGPoint.zero, size: CGSize.zero));
 
 	public var titleText: String? {
 		get {
@@ -57,7 +57,7 @@ open class PAPermissionsViewController: UIViewController, PAPermissionsViewDeleg
 		
 	}
 	
-	public var tintColor: UIColor! {
+	public var tintColor: UIColor {
 		get {
 			return self.permissionsView.tintColor
 		}
@@ -67,7 +67,7 @@ open class PAPermissionsViewController: UIViewController, PAPermissionsViewDeleg
 		}
 	}
 	
-	public var backgroundColor: UIColor! {
+	public var backgroundColor: UIColor? {
 		get {
 			return self.permissionsView.backgroundColor
 		}
@@ -87,7 +87,6 @@ open class PAPermissionsViewController: UIViewController, PAPermissionsViewDeleg
 		}
 	}
 	
-	@available (iOS 8, *)
 	public var useBlurBackground: Bool {
 		get {
 			return self.permissionsView.useBlurBackground
@@ -111,17 +110,15 @@ open class PAPermissionsViewController: UIViewController, PAPermissionsViewDeleg
 	}
 	
 	fileprivate func setupUI() {
-		let mainView = PAPermissionsView(frame: CGRect(origin: CGPoint.zero, size: CGSize.zero));
-		mainView.delegate = self
-		mainView.dataSource = self
-		self.view.addSubview(mainView)
-		self.permissionsView = mainView
+		permissionsView.delegate = self
+		permissionsView.dataSource = self
+		self.view.addSubview(permissionsView)
 		
-		mainView.translatesAutoresizingMaskIntoConstraints = false
-		mainView.superview!.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": mainView]))
-		mainView.superview!.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": mainView]))
-		mainView.backgroundColor = UIColor.white
-		mainView.continueButton.addTarget(self, action: #selector(PAPermissionsViewController.didContinue), for: .touchUpInside)
+		permissionsView.translatesAutoresizingMaskIntoConstraints = false
+		permissionsView.superview?.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": permissionsView]))
+		permissionsView.superview?.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[subview]-0-|", options: [], metrics: nil, views: ["subview": permissionsView]))
+		permissionsView.backgroundColor = UIColor.white
+		permissionsView.continueButton.addTarget(self, action: #selector(PAPermissionsViewController.didContinue), for: .touchUpInside)
 	}
 	
 	public func setupData(_ permissions: [PAPermissionsItem], handlers:[String: PAPermissionsCheck]) {


### PR DESCRIPTION
This project does a lot of implicit and forced unwrapping of vars.  That's generally discouraged in Swift since you lose the protection of explicitly handling optionality.

Also - several vars were declared as `weak` and were also being force-unwrapped.  This semantically doesn't make sense because weak vars, by definition, aren't retained and therefore must be optional.  Swift should have probably always thrown an error on this - but as of Swift 5.3 in Xcode 12 Beta, force-unwrapping a weak var will no longer compile (it crashes the compiler).  This PR fixes that.